### PR TITLE
Update sv_weaponry.lua

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
@@ -92,7 +92,7 @@ function GM:PlayerCanPickupWeapon(ply, wep, dropBlockingWeapon, isPickupProbe)
             mask = MASK_SOLID,
         }, wep)
 
-        if tr.Fraction == 1.0 or tr.Entity == ply then
+        if (tr.Fraction == 1.0 or tr.Entity == ply) and not tr.StartSolid then
             wep:SetPos(ply:GetShootPos())
         end
     end


### PR DESCRIPTION
fixed bug that allows weapons to be picked up through walls. When trace starts solid (for example large weapon spawned too close to wall) then tr.Fraction can return 1.0 through solid walls.